### PR TITLE
add nginx with ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ DEPLOYMENT_TOOL="heat-config-ansible heat-config-cfn-init heat-config-puppet hea
 Role Variables
 --------------
 
+The Galaxy portal runs through an `nginx` http proxy by default. The following
+variables enable you to set nginx in https mode:
+
+```
+nginx_https: true
+ssl_cert: /etc/certs/cert.pem
+ssl_key: /etc/certs/key.pem
+ssl_dhparam: /etc/certs/dhparam.pem
+```
+
+If `nginx_https` is set to `true`, the other ssl variables are required.
+You can either request a signed trusted certificate or generated self-signed
+certificate. An ansible role to generate self-signed certificate can be found
+in https://galaxy.ansible.com/LIP-Computing/ssl-certs/
+
 ```
 # Galaxy administrator username
 GALAXY_ADMIN_USERNAME: "{{galaxy_admin_username}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,10 @@ galaxy_db_port: 5432
 #################################
 # NGINX
 nginx_upload_store_path: "{{galaxy_db_dir}}/tmp/nginx_upload_store"
+nginx_https: false
+ssl_cert: /etc/certs/cert.pem
+ssl_key: /etc/certs/key.pem
+ssl_dhparam: /etc/certs/dhparam.pem
 
 #################################
 # PROFTPD

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -38,11 +38,21 @@ http {
     gzip_disable "MSIE [1-6].(?!.*SV1)";
 
     server {
+{% if nginx_https %}
+        listen 443 http2 ssl;
+        listen [::]:443 http2 ssl;
+        ssl_certificate {{ ssl_cert }};
+        ssl_certificate_key {{ ssl_key }};
+        ssl_dhparam {{ ssl_dhparam }};
+{% endif %}
         client_max_body_size {{ nginx_client_max_body_size }};
         listen       {{ nginx_listen_port }};
         server_name  {{ nginx_server_name }};
 
         location / {
+{% if nginx_https %}
+            proxy_set_header X-URL-SCHEME https;
+{% endif %}
             root   html;
             index  index.html index.htm;
         }


### PR DESCRIPTION
nginx/galaxy portal with https/ssl
default is http, but can be set with nginx_https: true
than the cert and key have to be set
the role has been tested in a docker image