### PR TITLE
Enable conda by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,7 +68,7 @@ export_dir: "/export"
 refdata_dir: "/refdata"
 
 # Enable Conda
-use_conda: True
+use_conda: true
 
 # Enable pbkdf2
 use_pbkdf2: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,9 @@ export_dir: "/export"
 #refdata_dir: "/refdata" # FIXME This is our default. The commit should be reverted and the path should be fixed for SLURM clusters.
 refdata_dir: "/refdata"
 
+# Enable Conda
+use_conda: true
+
 use_pbkdf2: true
 
 #################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,7 +73,7 @@ tool_deps_path: "{{ export_dir }}/tool_deps"
 # Enable Conda
 use_conda: true
 job_working_directory: "{{ export_dir }}/job_work_dir" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
-conda_prefix: "{{ tool_deps_path }}/_conda"
+conda_prefix: "{{ export_dir }}/_conda"
 conda_channels: "conda-forge,r,bioconda,iuc"
 
 # Update UCSC genome database

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,7 +73,7 @@ tool_deps_path: "{{ export_dir }}/tool_deps"
 # Enable Conda
 use_conda: true
 job_work_dir: "{{ export_dir }}/jwd" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
-conda_prefix: "{{ export_dir }}/_conda"
+conda_prefix: "{{ tool_deps_path }}/_conda"
 conda_channels: "defaults,conda-forge,r,bioconda,iuc"
 
 # Update UCSC genome database

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,12 +72,12 @@ tool_deps_path: "{{ export_dir }}/tool_deps"
 
 # Enable Conda
 use_conda: true
-job_work_dir: "{{ export_dir }}/jwd" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
+job_work_dir: "{{ export_dir }}/job_work_dir" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
 conda_prefix: "{{ tool_deps_path }}/_conda"
 conda_channels: "defaults,conda-forge,r,bioconda,iuc"
 
 # Update UCSC genome database
-update_ucsc: true
+update_ucsc: false
 fast_update: true # Force database update by copying cached files. Only for testing!
 
 # Enable pbkdf2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,7 +71,7 @@ refdata_dir: "/refdata"
 use_conda: true
 
 # Update UCSC genome database
-update_ucsc: true
+update_ucsc: false
 fast_update: true # Force database update by copying cached files. Only for testing!
 
 # Enable pbkdf2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,6 +70,10 @@ refdata_dir: "/refdata"
 # Enable Conda
 use_conda: true
 
+# Update UCSC genome database
+update_ucsc: true
+fast_update: true # Force database update by copying cached files. Only for testing!
+
 # Enable pbkdf2
 use_pbkdf2: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,8 +67,16 @@ export_dir: "/export"
 #refdata_dir: "/refdata" # FIXME This is our default. The commit should be reverted and the path should be fixed for SLURM clusters.
 refdata_dir: "/refdata"
 
+# Tool dependency directory
+tool_deps_path: "{{ export_dir }}/tool_deps"
+
 # Enable Conda
 use_conda: true
+job_working_directory: "{{ export_dir }}/job_work_dir" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
+conda_prefix: "{{ tool_deps_path }}/_conda"
+conda_channels: "conda-forge,r,bioconda,iuc"
+
+
 
 # Update UCSC genome database
 update_ucsc: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,9 +68,9 @@ export_dir: "/export"
 refdata_dir: "/refdata"
 
 # Enable Conda
-use_conda: true
+use_conda: True
 
-# Other
+# Enable pbkdf2
 use_pbkdf2: true
 
 #################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,8 +76,6 @@ job_working_directory: "{{ export_dir }}/job_work_dir" # From galaxy.ini: IMPORT
 conda_prefix: "{{ tool_deps_path }}/_conda"
 conda_channels: "conda-forge,r,bioconda,iuc"
 
-
-
 # Update UCSC genome database
 update_ucsc: false
 fast_update: true # Force database update by copying cached files. Only for testing!

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,7 +77,7 @@ conda_prefix: "{{ tool_deps_path }}/_conda"
 conda_channels: "conda-forge,r,bioconda,iuc"
 
 # Update UCSC genome database
-update_ucsc: false
+update_ucsc: true
 fast_update: true # Force database update by copying cached files. Only for testing!
 
 # Enable pbkdf2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,7 +72,7 @@ tool_deps_path: "{{ export_dir }}/tool_deps"
 
 # Enable Conda
 use_conda: true
-job_working_directory: "{{ export_dir }}/job_work_dir" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
+job_work_dir: "{{ export_dir }}/jwd" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
 conda_prefix: "{{ export_dir }}/_conda"
 conda_channels: "defaults,conda-forge,r,bioconda,iuc"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ tool_deps_path: "{{ export_dir }}/tool_deps"
 use_conda: true
 job_working_directory: "{{ export_dir }}/job_work_dir" # From galaxy.ini: IMPORTANT: Due to a current limitation in conda, the total length of the conda_prefix and the job_working_directory path should be less than 50 characters!
 conda_prefix: "{{ export_dir }}/_conda"
-conda_channels: "conda-forge,r,bioconda,iuc"
+conda_channels: "defaults,conda-forge,r,bioconda,iuc"
 
 # Update UCSC genome database
 update_ucsc: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,6 +70,7 @@ refdata_dir: "/refdata"
 # Enable Conda
 use_conda: true
 
+# Other
 use_pbkdf2: true
 
 #################################

--- a/tasks/conda.yml
+++ b/tasks/conda.yml
@@ -1,0 +1,11 @@
+---
+- name: Enable Conda
+  ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
+  with_items:
+#    - { section: 'app:main', option: 'conda_prefix', value: "{{ conda_prefix }}" }
+    - { section: 'app:main', option: 'job_working_directory', value: "{{ job_work_dir }}" } # change job working dir only when conda is enabled by default, to workaround current conda limitations.
+#    - { section: 'app:main', option: 'conda_ensure_channels', value: "{{ conda_channels }}" }
+    - { section: 'app:main', option: 'conda_auto_install', value: "True" }
+    - { section: 'app:main', option: 'conda_auto_init', value: "True" }
+  when: use_conda
+

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -7,24 +7,25 @@
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
     - { section: 'app:main', option: 'admin_users', value: "{{GALAXY_ADMIN_EMAIL}}" }
-    - { section: 'app:main', option: 'tool_dependency_dir', value: "{{galaxy_install_path}}/tool_dependency" }
+    - { section: 'app:main', option: 'tool_dependency_dir', value: "{{ tool_deps_path }}" }
     - { section: 'app:main', option: 'brand', value: "{{galaxy_instance_description}}" }
-    #- { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
-    #- { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
-    #- { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
-    #- { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
-    #- { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
-    #- { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
-    #- { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
-    #- { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
-    #- { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
-    #- { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
+    - { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
+    - { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
+    - { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
+    - { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
+    - { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
+    - { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
+    - { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
+    - { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
+    - { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
+    - { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
 
 - name: Enable Conda
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
-    #- { section: 'app:main', option: 'conda_prefix', value: "{{galaxy_install_path}}/tool_dependency/_conda" }
-    - { section: 'app:main', option: 'conda_ensure_channels', value: "conda-forge,r,bioconda,iuc" }
+    - { section: 'app:main', option: 'conda_prefix', value: "{{ conda_prefix }}" }
+    - { section: 'app:main', option: 'job_working_directory', value: "{{ job_work_dir }}" } # change job working dir only when conda is enabled by default, to workaround current conda limitations.
+    - { section: 'app:main', option: 'conda_ensure_channels', value: "{{ conda_channels }}" }
     - { section: 'app:main', option: 'conda_auto_install', value: "True" }
     - { section: 'app:main', option: 'conda_auto_init', value: "True" }
   when: use_conda

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -8,7 +8,7 @@
   with_items:
     - { section: 'app:main', option: 'admin_users', value: "{{ GALAXY_ADMIN_EMAIL }}" }
     - { section: 'app:main', option: 'brand', value: "{{ galaxy_instance_description }}" }
-#    - { section: 'app:main', option: 'tool_dependency_dir', value: "{{ tool_deps_path }}" }
+    - { section: 'app:main', option: 'tool_dependency_dir', value: "{{ tool_deps_path }}" }
 #    - { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
 #    - { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
 #    - { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
@@ -23,9 +23,9 @@
 - name: Enable Conda
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
-    #- { section: 'app:main', option: 'conda_prefix', value: "{{ conda_prefix }}" }
-    #- { section: 'app:main', option: 'job_working_directory', value: "{{ job_work_dir }}" } # change job working dir only when conda is enabled by default, to workaround current conda limitations.
-    #- { section: 'app:main', option: 'conda_ensure_channels', value: "{{ conda_channels }}" }
+    - { section: 'app:main', option: 'conda_prefix', value: "{{ conda_prefix }}" }
+    - { section: 'app:main', option: 'job_working_directory', value: "{{ job_work_dir }}" } # change job working dir only when conda is enabled by default, to workaround current conda limitations.
+    - { section: 'app:main', option: 'conda_ensure_channels', value: "{{ conda_channels }}" }
     - { section: 'app:main', option: 'conda_auto_install', value: "True" }
     - { section: 'app:main', option: 'conda_auto_init', value: "True" }
   when: use_conda

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -20,6 +20,15 @@
     - { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
     - { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
 
+- name: Enable Conda
+  ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
+  with_items:
+    - { section: 'app:main', option: 'conda_prefix', value: "{{galaxy_install_path}}/tool_dependency/_conda" }
+    - { section: 'app:main', option: 'conda_ensure_channels', value: "conda-forge,r,bioconda,iuc" }
+    - { section: 'app:main', option: 'conda_auto_install', value: "True" }
+    - { section: 'app:main', option: 'conda_auto_init', value: "True" }
+  when: use_conda == 'True'
+
 #---
 # Galaxy administrator: email. username, password and api_key
 # IMPORTANT: you need the galaxy database postgresql active to setup the galaxy administrator

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -27,7 +27,7 @@
     - { section: 'app:main', option: 'conda_ensure_channels', value: "conda-forge,r,bioconda,iuc" }
     - { section: 'app:main', option: 'conda_auto_install', value: "True" }
     - { section: 'app:main', option: 'conda_auto_init', value: "True" }
-  when: use_conda == 'True'
+  when: use_conda == "True"
 
 #---
 # Galaxy administrator: email. username, password and api_key

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -6,19 +6,19 @@
 - name: Galaxy configuration
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
-    - { section: 'app:main', option: 'admin_users', value: "{{GALAXY_ADMIN_EMAIL}}" }
-    - { section: 'app:main', option: 'tool_dependency_dir', value: "{{ tool_deps_path }}" }
-    - { section: 'app:main', option: 'brand', value: "{{galaxy_instance_description}}" }
-    - { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
-    - { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
-    - { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
-    - { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
-    - { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
-    - { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
-    - { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
-    - { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
-    - { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
-    - { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
+    - { section: 'app:main', option: 'admin_users', value: "{{ GALAXY_ADMIN_EMAIL }}" }
+    - { section: 'app:main', option: 'brand', value: "{{ galaxy_instance_description }}" }
+#    - { section: 'app:main', option: 'tool_dependency_dir', value: "{{ tool_deps_path }}" }
+#    - { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
+#    - { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
+#    - { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
+#    - { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
+#    - { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
+#    - { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
+#    - { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
+#    - { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
+#    - { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
+#    - { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
 
 - name: Enable Conda
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -55,3 +55,8 @@
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
     - { section: 'app:main', option: 'id_secret', value: "{{galaxy_id_secret.stdout}}" }
+
+#---
+# Update UCSC genome database
+- include: updateucsc.yml
+  when: update_ucsc

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -23,7 +23,6 @@
 - name: Enable Conda
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
-    - { section: 'app:main', option: 'conda_prefix', value: "{{galaxy_install_path}}/tool_dependency/_conda" }
     - { section: 'app:main', option: 'conda_ensure_channels', value: "conda-forge,r,bioconda,iuc" }
     - { section: 'app:main', option: 'conda_auto_install', value: "True" }
     - { section: 'app:main', option: 'conda_auto_init', value: "True" }

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -27,7 +27,7 @@
     - { section: 'app:main', option: 'conda_ensure_channels', value: "conda-forge,r,bioconda,iuc" }
     - { section: 'app:main', option: 'conda_auto_install', value: "True" }
     - { section: 'app:main', option: 'conda_auto_init', value: "True" }
-  when: use_conda == "True"
+  when: use_conda
 
 #---
 # Galaxy administrator: email. username, password and api_key

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -23,9 +23,9 @@
 - name: Enable Conda
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
-    - { section: 'app:main', option: 'conda_prefix', value: "{{ conda_prefix }}" }
-    - { section: 'app:main', option: 'job_working_directory', value: "{{ job_work_dir }}" } # change job working dir only when conda is enabled by default, to workaround current conda limitations.
-    - { section: 'app:main', option: 'conda_ensure_channels', value: "{{ conda_channels }}" }
+    #- { section: 'app:main', option: 'conda_prefix', value: "{{ conda_prefix }}" }
+    #- { section: 'app:main', option: 'job_working_directory', value: "{{ job_work_dir }}" } # change job working dir only when conda is enabled by default, to workaround current conda limitations.
+    #- { section: 'app:main', option: 'conda_ensure_channels', value: "{{ conda_channels }}" }
     - { section: 'app:main', option: 'conda_auto_install', value: "True" }
     - { section: 'app:main', option: 'conda_auto_init', value: "True" }
   when: use_conda

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -9,20 +9,21 @@
     - { section: 'app:main', option: 'admin_users', value: "{{GALAXY_ADMIN_EMAIL}}" }
     - { section: 'app:main', option: 'tool_dependency_dir', value: "{{galaxy_install_path}}/tool_dependency" }
     - { section: 'app:main', option: 'brand', value: "{{galaxy_instance_description}}" }
-    - { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
-    - { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
-    - { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
-    - { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
-    - { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
-    - { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
-    - { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
-    - { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
-    - { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
-    - { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
+    #- { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
+    #- { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
+    #- { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
+    #- { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
+    #- { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
+    #- { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
+    #- { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
+    #- { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
+    #- { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
+    #- { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
 
 - name: Enable Conda
   ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
   with_items:
+    #- { section: 'app:main', option: 'conda_prefix', value: "{{galaxy_install_path}}/tool_dependency/_conda" }
     - { section: 'app:main', option: 'conda_ensure_channels', value: "conda-forge,r,bioconda,iuc" }
     - { section: 'app:main', option: 'conda_auto_install', value: "True" }
     - { section: 'app:main', option: 'conda_auto_init', value: "True" }

--- a/tasks/galaxy-custom.yml
+++ b/tasks/galaxy-custom.yml
@@ -9,27 +9,20 @@
     - { section: 'app:main', option: 'admin_users', value: "{{ GALAXY_ADMIN_EMAIL }}" }
     - { section: 'app:main', option: 'brand', value: "{{ galaxy_instance_description }}" }
     - { section: 'app:main', option: 'tool_dependency_dir', value: "{{ tool_deps_path }}" }
-#    - { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" }
-#    - { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
-#    - { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
-#    - { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
-#    - { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
-#    - { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
-#    - { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
-#    - { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
-#    - { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
-#    - { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
+    - { section: 'app:main', option: 'job_working_directory', value: "{{galaxy_db_dir}}/job_working_directory" } # if conda is enabled, this config is modified.
+    - { section: 'app:main', option: 'file_path', value: "{{galaxy_db_dir}}/files" }
+    - { section: 'app:main', option: 'new_file_path', value: "{{galaxy_db_dir}}/tmp" }
+    - { section: 'app:main', option: 'template_cache_path', value: "{{galaxy_db_dir}}/compiled_templates" }
+    - { section: 'app:main', option: 'citation_cache_data_dir', value: "{{galaxy_db_dir}}/citations/data" }
+    - { section: 'app:main', option: 'citation_cache_lock_dir', value: "{{galaxy_db_dir}}/citations/lock" }
+    - { section: 'app:main', option: 'whoosh_index_dir', value: "{{galaxy_db_dir}}/whoosh_indexes" }
+    - { section: 'app:main', option: 'object_store_cache_path', value: "{{galaxy_db_dir}}/object_store_cache" }
+    - { section: 'app:main', option: 'cluster_file_directory', value: "{{galaxy_db_dir}}/pbs" }
+    - { section: 'app:main', option: 'ftp_upload_dir', value: "{{galaxy_db_dir}}/ftp" }
 
-- name: Enable Conda
-  ini_file: dest={{galaxy_config_file}} section={{ item.section }} option={{ item.option }} value="{{ item.value }}"
-  with_items:
-    - { section: 'app:main', option: 'conda_prefix', value: "{{ conda_prefix }}" }
-    - { section: 'app:main', option: 'job_working_directory', value: "{{ job_work_dir }}" } # change job working dir only when conda is enabled by default, to workaround current conda limitations.
-    - { section: 'app:main', option: 'conda_ensure_channels', value: "{{ conda_channels }}" }
-    - { section: 'app:main', option: 'conda_auto_install', value: "True" }
-    - { section: 'app:main', option: 'conda_auto_init', value: "True" }
+# Enable conda by default
+- include: conda.yml
   when: use_conda
-
 #---
 # Galaxy administrator: email. username, password and api_key
 # IMPORTANT: you need the galaxy database postgresql active to setup the galaxy administrator

--- a/tasks/galaxy-install.yml
+++ b/tasks/galaxy-install.yml
@@ -2,7 +2,7 @@
 # This recipe downloads galaxy, setup python virtualenv and create the galaxy.ini file
 
 - name: Get Galaxy
-  git: repo=https://github.com/galaxyproject/galaxy/
+  git: repo=https://github.com/galaxyproject/galaxy.git
        clone=yes
        dest={{galaxy_install_path}}
        version={{GALAXY_VERSION}}

--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -49,35 +49,17 @@
 #########################################################
 # Create directories
 
-- name: Create log directory
-  file: path={{galaxy_log_path}}
+- name: Create directoryes
+  file: path={{ item }}
         state=directory
         owner={{galaxy_user}}
         group={{galaxy_user}}
-  become_user: root
-  become_method: sudo
-
-- name: Create export directory
-  file: path={{export_dir}}
-        state=directory
-        owner={{galaxy_user}}
-        group={{galaxy_user}}
-  become_user: root
-  become_method: sudo
-
-- name: Create reference data directory
-  file: path={{refdata_dir}}
-        state=directory
-        owner={{galaxy_user}}
-        group={{galaxy_user}}
-  become_user: root
-  become_method: sudo
-
-- name: Create /etc/galaxy directory
-  file: path=/etc/galaxy
-        state=directory
-        owner={{galaxy_user}}
-        group={{galaxy_user}}
+  with_items:
+    - {{ galaxy_log_path }}
+    - {{ export_dir }}
+    - {{ refdata_dir }}
+    - /etc/galaxy
+    - {{ tool_deps_path }}
   become_user: root
   become_method: sudo
 

--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -55,11 +55,11 @@
         owner={{galaxy_user}}
         group={{galaxy_user}}
   with_items:
-    - {{ galaxy_log_path }}
-    - {{ export_dir }}
-    - {{ refdata_dir }}
-    - /etc/galaxy
-    - {{ tool_deps_path }}
+    - '{{ galaxy_log_path }}'
+    - '{{ export_dir }}'
+    - '{{ refdata_dir }}'
+    - '/etc/galaxy'
+    - '{{ tool_deps_path }}'
   become_user: root
   become_method: sudo
 

--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -49,7 +49,7 @@
 #########################################################
 # Create directories
 
-- name: Create directoryes
+- name: Create directories
   file: path={{ item }}
         state=directory
         owner={{galaxy_user}}

--- a/tasks/updateucsc.yml
+++ b/tasks/updateucsc.yml
@@ -11,6 +11,7 @@
     url: 'http://cloud.recas.ba.infn.it:8080/v1/AUTH_3b4918e0a982493e8c3ebcc43586a2a8/INDIGO-REVIEW/ucsc.tar.gz'
     dest: /tmp/ucsc.tar.gz
     force: yes
+    timeout: 100
   when: fast_update
 
 - name: Copy ucsc genome indexes

--- a/tasks/updateucsc.yml
+++ b/tasks/updateucsc.yml
@@ -7,10 +7,7 @@
 # Fast Update (only for testing)
 
 - name: Download ucsc genome idexes
-  get_url: url="http://cloud.recas.ba.infn.it:8080/v1/AUTH_3b4918e0a982493e8c3ebcc43586a2a8/INDIGO-REVIEW/ucsc.tar.gz"
-  args:
-    dest: "/tmp/ucsc.tar.gz"
-    force: "yes"
+  get_url: url=http://cloud.recas.ba.infn.it:8080/v1/AUTH_3b4918e0a982493e8c3ebcc43586a2a8/INDIGO-REVIEW/ucsc.tar.gz dest=/tmp/ucsc.tar.gz force=yes
   when: fast_update
 
 - name: Copy ucsc genome indexes

--- a/tasks/updateucsc.yml
+++ b/tasks/updateucsc.yml
@@ -1,0 +1,18 @@
+---
+# Update ucsc genome database
+
+# Default Update via updateucsc.sh script
+# FIXME add cronjob
+
+# Fast Update (only for testing)
+
+- name: Download ucsc genome idexes
+  get_url: url="http://cloud.recas.ba.infn.it:8080/v1/AUTH_3b4918e0a982493e8c3ebcc43586a2a8/INDIGO-REVIEW/ucsc.tar.gz"
+  args:
+    dest: "/tmp/"
+    force: "yes"
+  when: fast_update
+
+- name: Copy ucsc genome indexes
+  unarchive: src=/tmp/ucsc.tar.gz dest=/home/galaxy/galaxy/tool-data/shared/ remote_src=yes
+  when: fast_update

--- a/tasks/updateucsc.yml
+++ b/tasks/updateucsc.yml
@@ -7,7 +7,10 @@
 # Fast Update (only for testing)
 
 - name: Download ucsc genome idexes
-  get_url: url=http://cloud.recas.ba.infn.it:8080/v1/AUTH_3b4918e0a982493e8c3ebcc43586a2a8/INDIGO-REVIEW/ucsc.tar.gz dest=/tmp/ucsc.tar.gz force=yes
+  get_url:
+    url: 'http://cloud.recas.ba.infn.it:8080/v1/AUTH_3b4918e0a982493e8c3ebcc43586a2a8/INDIGO-REVIEW/ucsc.tar.gz'
+    dest: /tmp/ucsc.tar.gz
+    force: yes
   when: fast_update
 
 - name: Copy ucsc genome indexes

--- a/tasks/updateucsc.yml
+++ b/tasks/updateucsc.yml
@@ -9,7 +9,7 @@
 - name: Download ucsc genome idexes
   get_url: url="http://cloud.recas.ba.infn.it:8080/v1/AUTH_3b4918e0a982493e8c3ebcc43586a2a8/INDIGO-REVIEW/ucsc.tar.gz"
   args:
-    dest: "/tmp/"
+    dest: "/tmp/ucsc.tar.gz"
     force: "yes"
   when: fast_update
 

--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -42,6 +42,7 @@
   blockinfile:
     dest: "{{galaxy_config_file}}"
     marker: ""
+    insertafter: EOF
     content: |
       #
       # ---- uWSGI -------------------------------------------------------------------------

--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -59,6 +59,7 @@
     - { section: 'uwsgi', option: 'pythonhome', value: '{{galaxy_venv_path}}' }
     - { section: 'uwsgi', option: 'threads', value: '{{uwsgi_threads}}' }
     - { section: 'uwsgi', option: 'logto', value: '{{uwsgi_errorlog}}' }
+    - { section: 'uwsgi', option: 'pidfile', value: '{{ uwsgi_pidfile }}' }
 
 - name: if proc==1
   ini_file: dest={{galaxy_config_file}}

--- a/templates/galaxy_service.j2
+++ b/templates/galaxy_service.j2
@@ -9,9 +9,9 @@
 ################################################
 
 # Load Galaxy environment
-echo "Loading Galaxy environment"
-cd {{galaxy_install_path}}
-. {{galaxy_venv_path}}/bin/activate
+#echo "Loading Galaxy environment"
+#cd {{galaxy_install_path}}
+#. {{galaxy_venv_path}}/bin/activate
 
 # Define supervisord restart function
 function restart_galaxy {

--- a/templates/galaxy_startup.j2
+++ b/templates/galaxy_startup.j2
@@ -7,9 +7,9 @@
 ################################################
 
 # Load Galaxy environment
-#echo "Loading Galaxy environment"
-#cd {{galaxy_install_path}}
-#. {{galaxy_venv_path}}/bin/activate
+echo "Loading Galaxy environment"
+cd {{galaxy_install_path}}
+. {{galaxy_venv_path}}/bin/activate
 
 # Define supervisord start function
 function start_supervisord {

--- a/templates/galaxy_startup.j2
+++ b/templates/galaxy_startup.j2
@@ -7,9 +7,9 @@
 ################################################
 
 # Load Galaxy environment
-echo "Loading Galaxy environment"
-cd {{galaxy_install_path}}
-. {{galaxy_venv_path}}/bin/activate
+#echo "Loading Galaxy environment"
+#cd {{galaxy_install_path}}
+#. {{galaxy_venv_path}}/bin/activate
 
 # Define supervisord start function
 function start_supervisord {

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -1,20 +1,3 @@
-# This is a sample supervisor config file.
-# In this configuration, 2 handlers and 1 uwsgi (uwsgi is more performant than the default Paste) instance with 2 processes and 2 threads will be started.
-# In order for this to work, you will need to have a [uwsgi] section in galaxy.ini, as such:
-#
-# [uwsgi]
-# master = True
-#
-# Further, this assumes uwsgi has been installed through pip into a virtualenv (/home/galaxy/galaxy/.venv/, in this example). 
-# If this is not the case, adjust the path to uwsgi accordingly.
-# If uwsgi was not installed through pip, include "--plugin python" in the uwsgi command.
-# This configuration has been tested with galaxy release_16.01 and uWSGI==2.0.12.
-# This assumes galaxy is installed in /home/galaxy/galaxy, so change occurences of /home/galaxy/galaxy accordingly.
-# If you want to run galaxy under a different username, change "user = galaxy" to "user = <your user>".
-# You will probably want to proxy uwsgi (you can't connect with a browser to uwsgi port 4001) with nginx or apache, 
-# see https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-1
-# or https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-2 . 
-
 {% if supervisor_manage_postgres == "True" %}
 
 {% if ansible_virtualization_type != "docker" %}
@@ -62,24 +45,24 @@ killasgroup     = true
 {% endif %}
 
 [program:galaxy_web]
-command         = {{galaxy_venv_path}}/bin/uwsgi --ini-paste {{galaxy_config_file}}
-directory       = {{galaxy_install_path}}
+command         = {{ galaxy_venv_path }}/bin/uwsgi --virtualenv {{ galaxy_venv_path }} --ini-paste {{ galaxy_config_file }}
+directory       = {{ galaxy_install_path }}
 umask           = 022
 autostart       = true
 autorestart     = true
 startsecs       = 20
 user            = {{galaxy_user}}
 {%if galaxy_lrms == "slurm"%}
-environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s",PYTHONHOME="{{galaxy_venv_path}}",DRMAA_LIBRARY_PATH="/usr/local/lib/libdrmaa.so"
+environment     = PATH="{{ galaxy_venv_path }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",DRMAA_LIBRARY_PATH="/usr/local/lib/libdrmaa.so"
 {% else %}
-environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s"
+environment     = PATH="{{ galaxy_venv_path }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 {% endif %}
 numprocs        = 1
 stopsignal      = INT
 startretries    = 15
 
 [program:handler]
-command         = {{galaxy_venv_path}}/bin/python ./scripts/galaxy-main -c {{galaxy_config_file}} --server-name=handler%(process_num)s --log-file={{galaxy_log_path}}/handler%(process_num)s.log
+command         = {{ galaxy_venv_path }}/bin/python ./lib/galaxy/main.py -c {{ galaxy_config_file }} --server-name=handler%(process_num)s --log-file={{ galaxy_log_path }}/handler%(process_num)s.log
 directory       = {{galaxy_install_path}}
 process_name    = handler%(process_num)s
 numprocs        = 6
@@ -89,9 +72,7 @@ autorestart     = true
 startsecs       = 20
 user            = {{galaxy_user}}
 {%if galaxy_lrms == "slurm"%}
-environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s",PYTHONHOME="{{galaxy_venv_path}}",DRMAA_LIBRARY_PATH="/usr/local/lib/libdrmaa.so"
-{% else %}
-environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s"
+environment     = DRMAA_LIBRARY_PATH="/usr/local/lib/libdrmaa.so"
 {% endif %}
 startretries    = 15
 

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -72,7 +72,7 @@ user            = {{galaxy_user}}
 {%if galaxy_lrms == "slurm"%}
 environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s",PYTHONHOME="{{galaxy_venv_path}}",DRMAA_LIBRARY_PATH="/usr/local/lib/libdrmaa.so"
 {% else %}
-environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s",PYTHONHOME="{{galaxy_venv_path}}"
+environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s"
 {% endif %}
 numprocs        = 1
 stopsignal      = INT
@@ -91,7 +91,7 @@ user            = {{galaxy_user}}
 {%if galaxy_lrms == "slurm"%}
 environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s",PYTHONHOME="{{galaxy_venv_path}}",DRMAA_LIBRARY_PATH="/usr/local/lib/libdrmaa.so"
 {% else %}
-environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s",PYTHONHOME="{{galaxy_venv_path}}"
+environment     = VIRTUAL_ENV="{{galaxy_venv_path}}",PATH="{{galaxy_venv_path}}/bin:%(ENV_PATH)s"
 {% endif %}
 startretries    = 15
 


### PR DESCRIPTION
This commit enable conda by default. It is used by default in galaxy to solve dependencies (since 17.01 release).
- new conda recipe.
- fix uwsgi config in supervisord

